### PR TITLE
Set working nixpkgs hash into default.nix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## ??? -- 2019-??-??
 * Move more internal strings from String to Text
 * Add descriptions of offenses
+* Add `nix-linter -` to lint the contents of STDIN.
 
 ## 0.2.0.0 -- 2018-12-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## ??? -- 2019-??-??
 * Move more internal strings from String to Text
 * Add descriptions of offenses
-* Add `nix-linter -` to lint the contents of STDIN.
 
 ## 0.2.0.0 -- 2018-12-19
 

--- a/default.nix
+++ b/default.nix
@@ -1,10 +1,14 @@
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import (builtins.fetchTarball {
+    url = https://github.com/NixOS/nixpkgs/archive/e6d726e5aa527e6f41ec06adeb7f0272294373c8.tar.gz;
+    sha256 = "0s09nfcl245pyyyqi9q8m1lfaiqms5sm81lcpmvvsh5988iylcfx";
+  }) { }
+}:
 with pkgs;
 
 (haskellPackages.override ({
     overrides = self: super: {
       streamly = super.streamly_0_5_2 or super.streamly_0_5_0 or super.streamly;
-      path-io = super.path-io_1_4_0 or super.path-io;
+      path-io = super.path-io_1_4_1 or super.path-io;
     };
 })).extend (haskell.lib.packageSourceOverrides {
   nix-linter = ./.;


### PR DESCRIPTION
nix-linter doesn't work with the recent haskell package set updates, so I think it's better set a nixpkgs working hash by default