### PR TITLE
Fix compatibility with hnix≥0.13.0

### DIFF
--- a/main/Main.hs
+++ b/main/Main.hs
@@ -95,9 +95,9 @@ listDirRecursive path = resolveDir' path >>= readDir
 
 parseFiles = S.mapMaybeM $ (\path ->
   parseNixFileLoc path >>= \case
-    Success parse -> do
+    Right parse -> do
       pure $ Just parse
-    Failure why -> do
+    Left why -> do
       liftIO $ whenNormal $ log $ "Failure when parsing:\n" <> pShow why
       pure Nothing)
 

--- a/nix-linter.cabal
+++ b/nix-linter.cabal
@@ -68,7 +68,7 @@ library
 
   build-depends:
     base >=4.9,
-    hnix >=0.8 && < 0.11,
+    hnix >=0.8 && < 0.14,
     data-fix,
     fixplate >= 0.1.7,
     cmdargs >= 0.10,

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -47,8 +47,8 @@ case_examples_match = do
       let check = checkCategories $ Set.toList category
 
       parsed <- parseNixFileLoc (exampleDir </> example) >>= \case
-        Success x   -> pure x
-        Failure err -> assertFailure (show err)
+        Right x  -> pure x
+        Left err -> assertFailure (show err)
 
       let offenses = Set.fromList $ offense <$> check parsed
       assertEqual strippedName offenses category


### PR DESCRIPTION
Raise upper bound on hnix.

hnix 0.13.0 replaced the `Result` type with `Either`[1].

[1]  https://github.com/haskell-nix/hnix/commit/2fea0dc330bd3b3da10c893847b21ffb0855dca1