### PR TITLE
fix UnusedLetBind: account for `inherit`

### DIFF
--- a/src/Nix/Linter/Tools/FreeVars.hs
+++ b/src/Nix/Linter/Tools/FreeVars.hs
@@ -1,9 +1,48 @@
-module Nix.Linter.Tools.FreeVars (freeVars, freeVars') where
+module Nix.Linter.Tools.FreeVars (freeVars, freeVars', freeVarsIgnoreTopBinds
+                                 , freeVarsIgnoreTopBinds') where
 import           Data.Set                 (Set)
 
 import           Nix.Expr.Types
 import           Nix.Expr.Types.Annotated
 import           Nix.TH                   (freeVars)
 
+import qualified Data.Set                 as Set
+import           Data.Maybe               (mapMaybe)
+import           Data.Fix                 (unFix, Fix (..))
+
 freeVars' :: NExprLoc -> Set VarName
 freeVars' = freeVars . stripAnnotation
+
+freeVarsIgnoreTopBinds' :: NExprLoc -> Set VarName
+freeVarsIgnoreTopBinds' = freeVarsIgnoreTopBinds . stripAnnotation
+
+-- gets the free variables of the expression, assuming the top level bindings
+-- were not bound. Note that this function is *not* recursive, since we want to
+-- count bindings deeper in the tree
+freeVarsIgnoreTopBinds :: NExpr -> Set VarName
+freeVarsIgnoreTopBinds e =
+  case unFix e of
+    (NSet NRecursive bindings) -> bindFreeVars bindings
+    (NAbs (Param _) expr) -> freeVars expr
+    (NAbs (ParamSet set _ _) expr) ->
+      freeVars expr <> (Set.unions $ freeVars <$> mapMaybe snd set)
+    (NLet bindings expr) -> freeVars expr <> bindFreeVars bindings
+    noTopBinds -> freeVars $ Fix noTopBinds
+ where
+  bindFreeVars :: Foldable t => t (Binding NExpr) -> Set VarName
+  bindFreeVars = foldMap bind1Free
+   where
+    bind1Free :: Binding NExpr -> Set VarName
+    bind1Free (Inherit  Nothing     keys _) = Set.fromList $ mapMaybe staticKey keys
+    bind1Free (Inherit (Just scope) _    _) = freeVars scope
+    bind1Free (NamedVar path        expr _) = pathFree path <> freeVars expr
+
+  staticKey :: NKeyName r -> Maybe VarName
+  staticKey (StaticKey  varname) = pure varname
+  staticKey (DynamicKey _      ) = mempty
+
+  pathFree :: NAttrPath NExpr -> Set VarName
+  pathFree = foldMap mapFreeVars
+
+  mapFreeVars :: Foldable t => t NExpr -> Set VarName
+  mapFreeVars = foldMap freeVars


### PR DESCRIPTION
This fixes #61 and additionally checks `inherit` statements for unused identifiers bound.

It changes the philosophy of checking for unused let bindings a little bit. Now it checks by removing each binding in turn and reconstructing the rest of the `let` statement, and then checking whether that name is free in the constructed let binding. If not, it wasn't being used.

For instance,
```
let
  x = 5;
  y = { z = 3;};
  inherit (y) z;
in
  x
```
Becomes internally
```
let
  y = {z = 3;};
  inherit (y) z;
in
  x
```
and now `x` is free, so we were using that binding. It also becomes
```
let
  x = 5;
  inherit (y) z;
in
  x
```
and now `y` is free, so we needed that binding too. Finally, it becomes
```
let
  x = 5;
  y = {z = 3;};
in
  x
```
And we discover that `z` is not free, so the last binding was not needed. If the `inherit` binds multiple values, it will check each of them separately.